### PR TITLE
Улучшил интеграцию с трависом -- линтер, тесты, cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.o
 *.obj
 .idea
+*.swp
+bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
-#???
+language: cpp
 
-language: minimal
 dist: bionic
 
 cache:
-- pip
+    - pip
 before_install:
-- git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-- git fetch origin master
+    - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+    - git fetch origin master
 install:
-- sudo bash -c 'echo "deb http://us.archive.ubuntu.com/ubuntu/ bionic-updates universe" >> /etc/apt/sources.list'
-- sudo bash -c 'echo "deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates universe" >> /etc/apt/sources.list'
-- sudo apt-get update
-- sudo apt-get install valgrind clang-format
-- valgrind --version
-- clang-format --version
+    - sudo bash -c 'echo "deb http://us.archive.ubuntu.com/ubuntu/ bionic-updates universe" >> /etc/apt/sources.list'
+    - sudo bash -c 'echo "deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates universe" >> /etc/apt/sources.list'
+    - sudo apt-get update
+    - sudo apt-get install cmake
+    - cmake --version
+script:
+    - cd bin
+    - cmake ..
+    - make
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ script:
     - cd bin
     - cmake ..
     - make
+    - ./run_tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ install:
     - sudo apt-get update
     - sudo apt-get install cmake
     - cmake --version
+    - pip install cpplint
 script:
+    - cpplint --recursive --root="src" --filter=-legal/copyright src/
     - cd bin
     - cmake ..
     - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,49 @@
+############################################################################
+# Actual project.
+
 cmake_minimum_required(VERSION 3.12)
 project(DND_CPP)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS "-g -Wall -Wextra")
 include_directories(src)
 
-set(TRAVIS_TEST_SOURCES src/main_travis.cpp src/travis/travis.cpp)
+set(TRAVIS_SOURCES src/travis/travis.cpp)
+set(TRAVIS_MAIN src/main_travis.cpp)
 
-add_executable(travis_test ${TRAVIS_TEST_SOURCES})
+add_executable(travis ${TRAVIS_SOURCES} ${TRAVIS_MAIN})
+
+############################################################################
+# Google Test setup.
+
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+  include_directories("${gtest_SOURCE_DIR}/include")
+endif()
+
+############################################################################
+# Unit tests.
+file(GLOB_RECURSE UNIT_TEST_SOURCES "src/*_test.cpp")
+add_executable(run_tests ${UNIT_TEST_SOURCES} ${TRAVIS_SOURCES})
+target_link_libraries(run_tests gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.12)
 project(DND_CPP)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS "-g -Wall -Wextra")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.13)
 project(DND_CPP)
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_FLAGS "-g -Wall -Wextra")
 include_directories(src)
 
 set(TRAVIS_TEST_SOURCES src/main_travis.cpp src/travis/travis.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(DND_CPP)
+set(CMAKE_CXX_STANDARD 20)
+include_directories(src)
+
+set(TRAVIS_TEST_SOURCES src/main_travis.cpp src/travis/travis.cpp)
+
+add_executable(travis_test ${TRAVIS_TEST_SOURCES})

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/src/main_travis.cpp
+++ b/src/main_travis.cpp
@@ -5,5 +5,5 @@
 int main() {
     int a, b;
     std::cin >> a >> b;
-    std::ciut << sum(a, b) << std::endl;
+    std::cout << sum(a, b) << std::endl;
 }

--- a/src/main_travis.cpp
+++ b/src/main_travis.cpp
@@ -5,5 +5,5 @@
 int main() {
     int a, b;
     std::cin >> a >> b;
-    std::cout << sum(a, b) << std::endl;
+    std::cout << Sum(a, b) << std::endl;
 }

--- a/src/main_travis.cpp
+++ b/src/main_travis.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+#include "travis/travis.h"
+
+int main() {
+    int a, b;
+    std::cin >> a >> b;
+    std::ciut << sum(a, b) << std::endl;
+}

--- a/src/travis/travis.cpp
+++ b/src/travis/travis.cpp
@@ -1,5 +1,5 @@
 #include "travis/travis.h"
 
-int sum(int a, int b) {
+int Sum(int a, int b) {
     return a + b;
 }

--- a/src/travis/travis.cpp
+++ b/src/travis/travis.cpp
@@ -1,0 +1,5 @@
+#include "travis/travis.h"
+
+int sum(int a, int b) {
+    return a + b;
+}

--- a/src/travis/travis.h
+++ b/src/travis/travis.h
@@ -1,6 +1,6 @@
-#ifndef TRAVIS_H_
-#define TRAVIS_H_
+#ifndef TRAVIS_TRAVIS_H_
+#define TRAVIS_TRAVIS_H_
 
 int sum(int a, int b);
 
-#endif // TRAVIS_H_
+#endif  // TRAVIS_TRAVIS_H_

--- a/src/travis/travis.h
+++ b/src/travis/travis.h
@@ -1,6 +1,6 @@
 #ifndef TRAVIS_TRAVIS_H_
 #define TRAVIS_TRAVIS_H_
 
-int sum(int a, int b);
+int Sum(int a, int b);
 
 #endif  // TRAVIS_TRAVIS_H_

--- a/src/travis/travis.h
+++ b/src/travis/travis.h
@@ -1,0 +1,6 @@
+#ifndef TRAVIS_H_
+#define TRAVIS_H_
+
+int sum(int a, int b);
+
+#endif // TRAVIS_H_

--- a/src/travis/travis_test.cpp
+++ b/src/travis/travis_test.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-    
+
 #include "travis/travis.h"
 
 TEST(Sum, AddsValues) {

--- a/src/travis/travis_test.cpp
+++ b/src/travis/travis_test.cpp
@@ -1,0 +1,7 @@
+#include "gtest/gtest.h"
+    
+#include "travis/travis.h"
+
+TEST(Sum, AddsValues) {
+    EXPECT_EQ(Sum(1, 2), 4);
+}

--- a/src/travis/travis_test.cpp
+++ b/src/travis/travis_test.cpp
@@ -3,5 +3,5 @@
 #include "travis/travis.h"
 
 TEST(Sum, AddsValues) {
-    EXPECT_EQ(Sum(1, 2), 4);
+    EXPECT_EQ(Sum(1, 2), 3);
 }


### PR DESCRIPTION
- Linter проверяет Google style guide: https://google.github.io/styleguide/cppguide.html . Там есть некоторые штуки, которые сильно мешают (типа обязательных копирайтов в каждом файле итд), если попадается что-то такое -- добавляейте в фильтры линтера или пишите мне. 
- Структура кода -- опять же по гуглостилю хэдеры, cpp и тесты лежат в одной папке, если файл называется a.cpp, то тест к нему a_test.cpp. Названия файлов маленькими буквами через подчеркивание.  